### PR TITLE
fix(package): remove "type" module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "license": "Apache-2.0",
   "sideEffects": false,
-  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Removes the "type" field from package.json as it is not required for the current build setup.