### PR TITLE
feat(env-utils): add env var utility for flexible prefixes

### DIFF
--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from 'ai';
 
 import { createLLMGateway } from '@/src';
+import { getEnvVar } from '@/src/env-utils';
 import { generateText } from 'ai';
 import { it, vi } from 'vitest';
 
@@ -15,8 +16,8 @@ const prompts = [
 describe('Vercel AI SDK basic', () => {
   it('should work', async () => {
     const llmgateway = createLLMGateway({
-      apiKey: process.env.LLMGATEWAY_API_KEY,
-      baseURL: `${process.env.LLMGATEWAY_API_BASE}/v1`,
+      apiKey: getEnvVar('API_KEY'),
+      baseURL: `${getEnvVar('API_BASE')}/v1`,
     });
 
     const model = llmgateway('claude-3-7-sonnet', {

--- a/e2e/cache-control.test.ts
+++ b/e2e/cache-control.test.ts
@@ -1,4 +1,5 @@
 import { createLLMGateway } from '@/src';
+import { getEnvVar } from '@/src/env-utils';
 import { streamText } from 'ai';
 import { it, vi } from 'vitest';
 
@@ -35,8 +36,8 @@ it.skip('should trigger cache read', async () => {
 
 async function callLLM() {
   const llmgateway = createLLMGateway({
-    apiKey: process.env.LLMGATEWAY_API_KEY,
-    baseURL: `${process.env.LLMGATEWAY_API_BASE}/api/v1`,
+    apiKey: getEnvVar('API_KEY'),
+    baseURL: `${getEnvVar('API_BASE')}/api/v1`,
   });
   const model = llmgateway('anthropic/claude-3.7-sonnet', {
     usage: {

--- a/e2e/tools-with-reasoning.test.ts
+++ b/e2e/tools-with-reasoning.test.ts
@@ -6,6 +6,7 @@ import {
   sendSMSTool,
 } from '@/e2e/tools';
 import { createLLMGateway } from '@/src';
+import { getEnvVar } from '@/src/env-utils';
 import { generateText } from 'ai';
 import { it, vi } from 'vitest';
 
@@ -21,8 +22,8 @@ const prompts = [
 describe('Vercel AI SDK tools call with reasoning', () => {
   it.skip('should work with reasoning content', async () => {
     const llmgateway = createLLMGateway({
-      apiKey: process.env.LLMGATEWAY_API_KEY,
-      baseURL: `${process.env.LLMGATEWAY_API_BASE}/api/v1`,
+      apiKey: getEnvVar('API_KEY'),
+      baseURL: `${getEnvVar('API_BASE')}/api/v1`,
     });
 
     const model = llmgateway('anthropic/claude-sonnet-4', {

--- a/e2e/tools.ts
+++ b/e2e/tools.ts
@@ -1,12 +1,13 @@
 // ref: https://github.com/t3dotgg/SnitchScript/blob/main/tools.ts
 
 import { createLLMGateway } from '@/src';
+import { getEnvVar } from '@/src/env-utils';
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 
 const llmgateway = createLLMGateway({
-  apiKey: process.env.LLMGATEWAY_API_KEY,
-  baseURL: `${process.env.LLMGATEWAY_API_BASE}/api/v1`,
+  apiKey: getEnvVar('API_KEY'),
+  baseURL: `${getEnvVar('API_BASE')}/api/v1`,
 });
 
 export const sendSMSTool = tool({

--- a/e2e/usage-accounting.test.ts
+++ b/e2e/usage-accounting.test.ts
@@ -1,11 +1,12 @@
 import { createLLMGateway } from '@/src';
+import { getEnvVar } from '@/src/env-utils';
 import { streamText } from 'ai';
 import { it } from 'vitest';
 
 it.skip('receive usage accounting', async () => {
   const llmgateway = createLLMGateway({
-    apiKey: process.env.LLMGATEWAY_API_KEY,
-    baseURL: `${process.env.LLMGATEWAY_API_BASE}/api/v1`,
+    apiKey: getEnvVar('API_KEY'),
+    baseURL: `${getEnvVar('API_BASE')}/api/v1`,
   });
   const model = llmgateway('anthropic/claude-3.7-sonnet:thinking', {
     usage: {

--- a/example.env.e2e
+++ b/example.env.e2e
@@ -1,3 +1,8 @@
 # Rename to .env.e2e
+# You can use either LLMGATEWAY_ or LLM_GATEWAY_ prefixes
 LLMGATEWAY_API_BASE=https://api.llmgateway.io
 LLMGATEWAY_API_KEY=you-api-key-here
+
+# Alternative prefix format:
+# LLM_GATEWAY_API_BASE=https://api.llmgateway.io
+# LLM_GATEWAY_API_KEY=you-api-key-here

--- a/src/env-utils.ts
+++ b/src/env-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Utility function to get environment variables with support for both
+ * LLMGATEWAY_ and LLM_GATEWAY_ prefixes.
+ *
+ * @param key The environment variable key without the prefix (e.g., 'API_KEY')
+ * @returns The environment variable value or undefined if not found
+ */
+export function getEnvVar(key: string): string | undefined {
+  // Try LLMGATEWAY_ prefix first
+  const llmgatewayKey = `LLMGATEWAY_${key}`;
+  const llmgatewayValue = process.env[llmgatewayKey];
+
+  if (llmgatewayValue !== undefined) {
+    return llmgatewayValue;
+  }
+
+  // Fallback to LLM_GATEWAY_ prefix
+  const llmGatewayKey = `LLM_GATEWAY_${key}`;
+  return process.env[llmGatewayKey];
+}

--- a/src/llmgateway-provider.ts
+++ b/src/llmgateway-provider.ts
@@ -8,6 +8,7 @@ import type {
 } from './types/llmgateway-chat-settings';
 
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
+import { getEnvVar } from './env-utils';
 
 import { LLMGatewayChatLanguageModel } from './llmgateway-chat-language-model';
 import { LLMGatewayCompletionLanguageModel } from './llmgateway-completion-language-model';
@@ -100,7 +101,7 @@ export function createLLMGateway(
 
   const getHeaders = () => ({
     Authorization: `Bearer ${loadApiKey({
-      apiKey: options.apiKey,
+      apiKey: options.apiKey ?? getEnvVar('API_KEY'),
       environmentVariableName: 'LLMGATEWAY_API_KEY',
       description: 'LLMGateway',
     })}`,


### PR DESCRIPTION
Introduces a `getEnvVar` utility function to support fetching
environment variables with both `LLMGATEWAY_` and `LLM_GATEWAY_`
prefixes. Updates all references to environment variables to use
this new utility for consistent and flexible access.

BREAKING CHANGE: Environment variable handling now relies on
the `getEnvVar` utility, which supports dual prefixes. Ensure
that