### PR TITLE
fix(types): streamline LLMGateway chat model typing

### DIFF
--- a/src/chat/convert-to-llmgateway-chat-messages.ts
+++ b/src/chat/convert-to-llmgateway-chat-messages.ts
@@ -1,3 +1,4 @@
+import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 import type {
   LanguageModelV2FilePart,
   LanguageModelV2Prompt,
@@ -5,13 +6,13 @@ import type {
   LanguageModelV2ToolResultPart,
   SharedV2ProviderMetadata,
 } from '@ai-sdk/provider';
-import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 import type {
   ChatCompletionContentPart,
   LLMGatewayChatCompletionsInput,
 } from '../types/llmgateway-chat-completions-input';
 
 import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
+
 import { getFileUrl } from './file-url-utils';
 import { isUrl } from './is-url';
 

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV2FilePart } from '@ai-sdk/provider';
 
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
+
 import { isUrl } from './is-url';
 
 export function getFileUrl({

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -5,6 +5,7 @@ import {
   convertReadableStreamToArray,
   createTestServer,
 } from '@ai-sdk/provider-utils/test';
+
 import { createLLMGateway } from '../provider';
 import { ReasoningDetailType } from '../schemas/reasoning-details';
 
@@ -708,10 +709,11 @@ describe('doStream', () => {
     const elements = await convertReadableStreamToArray(stream);
 
     // Filter for reasoning-related elements
-    const reasoningElements = elements.filter(el =>
-      el.type === 'reasoning-start' ||
-      el.type === 'reasoning-delta' ||
-      el.type === 'reasoning-end'
+    const reasoningElements = elements.filter(
+      (el) =>
+        el.type === 'reasoning-start' ||
+        el.type === 'reasoning-delta' ||
+        el.type === 'reasoning-end',
     );
 
     // Debug output to see what we're getting
@@ -724,14 +726,17 @@ describe('doStream', () => {
 
     // Verify the content comes from reasoning_details, not reasoning field
     const reasoningDeltas = reasoningElements
-      .filter(el => el.type === 'reasoning-delta')
-      .map(el => (el as { type: 'reasoning-delta'; delta: string; id: string }).delta);
+      .filter((el) => el.type === 'reasoning-delta')
+      .map(
+        (el) =>
+          (el as { type: 'reasoning-delta'; delta: string; id: string }).delta,
+      );
 
     expect(reasoningDeltas).toEqual([
-      'Let me think about this...',  // from reasoning_details text
-      'User wants a greeting',        // from reasoning_details summary
-      '[REDACTED]',                   // from reasoning_details encrypted
-      'This reasoning is used',       // from reasoning field (no reasoning_details)
+      'Let me think about this...', // from reasoning_details text
+      'User wants a greeting', // from reasoning_details summary
+      '[REDACTED]', // from reasoning_details encrypted
+      'This reasoning is used', // from reasoning field (no reasoning_details)
     ]);
 
     // Verify that "This should be ignored..." and "Also ignored" are NOT in the output

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1,3 +1,7 @@
+import type { FinishReason } from 'ai';
+import type { z } from 'zod/v4';
+import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
+import type { LLMGatewayUsageAccounting } from '@/src/types/index';
 import type {
   LanguageModelV2,
   LanguageModelV2CallOptions,
@@ -10,14 +14,12 @@ import type {
   SharedV2Headers,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
-import type { FinishReason } from 'ai';
-import type { z } from 'zod/v4';
-import type { LLMGatewayUsageAccounting } from '@/src/types/index';
 import type {
   LLMGatewayChatModelId,
   LLMGatewayChatSettings,
 } from '../types/llmgateway-chat-settings';
 
+import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 import { InvalidResponseDataError } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -27,7 +29,7 @@ import {
   isParsableJson,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
-import { ReasoningDetailType, type ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
+
 import { llmgatewayFailedResponseHandler } from '../schemas/error-response';
 import { mapLLMGatewayFinishReason } from '../utils/map-finish-reason';
 import { convertToLLMGatewayChatMessages } from './convert-to-llmgateway-chat-messages';
@@ -276,7 +278,10 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
               }
               return null;
             })
-            .filter((p: LanguageModelV2Content | null): p is LanguageModelV2Content => p !== null)
+            .filter(
+              (p: LanguageModelV2Content | null): p is LanguageModelV2Content =>
+                p !== null,
+            )
         : choice.message.reasoning
           ? [
               {
@@ -524,7 +529,6 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
               });
             };
 
-            
             if (delta.reasoning_details && delta.reasoning_details.length > 0) {
               for (const detail of delta.reasoning_details) {
                 switch (detail.type) {

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+
 import { LLMGatewayErrorResponseSchema } from '../schemas/error-response';
 import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
 

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -1,3 +1,6 @@
+import type { FinishReason } from 'ai';
+import type { z } from 'zod/v4';
+import type { LLMGatewayChatModelId } from '@/src/types/llmgateway-chat-settings';
 import type {
   LanguageModelV2,
   LanguageModelV2CallOptions,
@@ -5,13 +8,8 @@ import type {
   LanguageModelV2Usage,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
-import type { FinishReason } from 'ai';
-import type { z } from 'zod/v4';
 import type { LLMGatewayUsageAccounting } from '../types';
-import type {
-  LLMGatewayCompletionModelId,
-  LLMGatewayCompletionSettings,
-} from '../types/llmgateway-completion-settings';
+import type { LLMGatewayCompletionSettings } from '../types/llmgateway-completion-settings';
 
 import { UnsupportedFunctionalityError } from '@ai-sdk/provider';
 import {
@@ -21,6 +19,7 @@ import {
   generateId,
   postJsonToApi,
 } from '@ai-sdk/provider-utils';
+
 import { llmgatewayFailedResponseHandler } from '../schemas/error-response';
 import { mapLLMGatewayFinishReason } from '../utils/map-finish-reason';
 import { convertToLLMGatewayCompletionPrompt } from './convert-to-llmgateway-completion-prompt';
@@ -38,7 +37,7 @@ type LLMGatewayCompletionConfig = {
 export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
   readonly specificationVersion = 'v2' as const;
   readonly provider = 'llmgateway';
-  readonly modelId: LLMGatewayCompletionModelId;
+  readonly modelId: LLMGatewayChatModelId;
   readonly supportedUrls: Record<string, RegExp[]> = {
     'image/*': [
       /^data:image\/[a-zA-Z]+;base64,/,
@@ -53,7 +52,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
   private readonly config: LLMGatewayCompletionConfig;
 
   constructor(
-    modelId: LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings: LLMGatewayCompletionSettings,
     config: LLMGatewayCompletionConfig,
   ) {

--- a/src/completion/schemas.ts
+++ b/src/completion/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+
 import { LLMGatewayErrorResponseSchema } from '../schemas/error-response';
 import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
 

--- a/src/facade.ts
+++ b/src/facade.ts
@@ -3,12 +3,10 @@ import type {
   LLMGatewayChatModelId,
   LLMGatewayChatSettings,
 } from './types/llmgateway-chat-settings';
-import type {
-  LLMGatewayCompletionModelId,
-  LLMGatewayCompletionSettings,
-} from './types/llmgateway-completion-settings';
+import type { LLMGatewayCompletionSettings } from './types/llmgateway-completion-settings';
 
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
+
 import { LLMGatewayChatLanguageModel } from './chat';
 import { LLMGatewayCompletionLanguageModel } from './completion';
 
@@ -68,7 +66,7 @@ Custom headers to include in the requests.
   }
 
   completion(
-    modelId: LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings: LLMGatewayCompletionSettings = {},
   ) {
     return new LLMGatewayCompletionLanguageModel(modelId, settings, {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -18,8 +18,6 @@ import { zaiModels } from './zai';
 
 export type Provider = (typeof providers)[number]['id'];
 
-export type Model = (typeof models)[number]['providers'][number]['modelName'];
-
 export interface ProviderModelMapping {
   providerId: (typeof providers)[number]['id'];
   modelName: string;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -3,10 +3,7 @@ import type {
   LLMGatewayChatModelId,
   LLMGatewayChatSettings,
 } from './types/llmgateway-chat-settings';
-import type {
-  LLMGatewayCompletionModelId,
-  LLMGatewayCompletionSettings,
-} from './types/llmgateway-completion-settings';
+import type { LLMGatewayCompletionSettings } from './types/llmgateway-completion-settings';
 
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils';
 
@@ -46,7 +43,7 @@ Creates an LLMGateway chat model for text generation.
 Creates an LLMGateway completion model for text generation.
    */
   completion(
-    modelId: LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings?: LLMGatewayCompletionSettings,
   ): LLMGatewayCompletionLanguageModel;
 }
@@ -127,7 +124,7 @@ export function createLLMGateway(
     });
 
   const createCompletionModel = (
-    modelId: LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings: LLMGatewayCompletionSettings = {},
   ) =>
     new LLMGatewayCompletionLanguageModel(modelId, settings, {
@@ -140,7 +137,7 @@ export function createLLMGateway(
     });
 
   const createLanguageModel = (
-    modelId: LLMGatewayChatModelId | LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings?: LLMGatewayChatSettings | LLMGatewayCompletionSettings,
   ) => {
     if (new.target) {
@@ -160,7 +157,7 @@ export function createLLMGateway(
   };
 
   const provider = (
-    modelId: LLMGatewayChatModelId | LLMGatewayCompletionModelId,
+    modelId: LLMGatewayChatModelId,
     settings?: LLMGatewayChatSettings | LLMGatewayCompletionSettings,
   ) => createLanguageModel(modelId, settings);
 

--- a/src/tests/provider-options.test.ts
+++ b/src/tests/provider-options.test.ts
@@ -3,6 +3,7 @@ import type { ModelMessage } from 'ai';
 import { createTestServer } from '@ai-sdk/provider-utils/test';
 import { streamText } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
+
 import { createLLMGateway } from '../provider';
 
 // Add type assertions for the mocked classes

--- a/src/tests/stream-usage-accounting.test.ts
+++ b/src/tests/stream-usage-accounting.test.ts
@@ -5,6 +5,7 @@ import {
   createTestServer,
 } from '@ai-sdk/provider-utils/test';
 import { describe, expect, it } from 'vitest';
+
 import { LLMGatewayChatLanguageModel } from '../chat';
 
 describe('LLMGateway Streaming Usage Accounting', () => {

--- a/src/tests/usage-accounting.test.ts
+++ b/src/tests/usage-accounting.test.ts
@@ -2,6 +2,7 @@ import type { LLMGatewayChatSettings } from '../types/llmgateway-chat-settings';
 
 import { createTestServer } from '@ai-sdk/provider-utils/test';
 import { describe, expect, it } from 'vitest';
+
 import { LLMGatewayChatLanguageModel } from '../chat';
 
 describe('LLMGateway Usage Accounting', () => {

--- a/src/types/llmgateway-chat-settings.ts
+++ b/src/types/llmgateway-chat-settings.ts
@@ -2,11 +2,9 @@ import type { LLMGatewaySharedSettings } from '..';
 import type { models, Provider } from '../models';
 
 // Available models can be found at the LLMGateway API endpoint
-type ProviderModelName =
-  (typeof models)[number]['providers'][number]['modelName'];
 export type LLMGatewayChatModelId =
   | (typeof models)[number]['id']
-  | `${Provider}/${ProviderModelName}`
+  | `${Provider}/${(typeof models)[number]['id']}`
   | 'test-model';
 
 export type LLMGatewayChatSettings = {

--- a/src/types/llmgateway-completion-settings.ts
+++ b/src/types/llmgateway-completion-settings.ts
@@ -1,12 +1,4 @@
 import type { LLMGatewaySharedSettings } from '.';
-import type { models, Provider } from '../models';
-
-type ProviderModelName =
-  (typeof models)[number]['providers'][number]['modelName'];
-
-export type LLMGatewayCompletionModelId =
-  | (typeof models)[number]['id']
-  | `${Provider}/${ProviderModelName}`;
 
 export type LLMGatewayCompletionSettings = {
   /**


### PR DESCRIPTION
Removes redundant `ProviderModelName` type and simplifies the typing of `LLMGatewayChatModelId`. Updates related types to enhance consistency and maintainability.