### PR TITLE
feat(chat): add structured JSON schema output support

### DIFF
--- a/e2e/json-schema.test.ts
+++ b/e2e/json-schema.test.ts
@@ -1,0 +1,74 @@
+import { generateObject, streamObject } from 'ai';
+import { it, expect, vi } from 'vitest';
+import { createLLMGateway } from '@/src';
+import { z } from 'zod';
+
+vi.setConfig({
+  testTimeout: 42_000,
+});
+
+const schema = z.object({
+  recipe: z.object({
+    name: z.string().describe('Name of the recipe'),
+    ingredients: z.array(z.object({
+      name: z.string().describe('Name of the ingredient'),
+      amount: z.string().describe('Amount of the ingredient'),
+    })).describe('List of ingredients'),
+    steps: z.array(z.string()).describe('Cooking steps'),
+  }).describe('Recipe details'),
+});
+
+it('should generate structured output with json_schema using generateObject', async () => {
+  const llmgateway = createLLMGateway({
+    apiKey: process.env.LLM_GATEWAY_API_KEY,
+    baseUrl: process.env.LLM_GATEWAY_API_BASE,
+  });
+  const model = llmgateway('gpt-4o-mini');
+
+  const result = await generateObject({
+    model,
+    schema,
+    mode: 'json',
+    prompt: 'Generate a simple recipe for chocolate chip cookies.',
+  });
+
+  expect(result.object).toBeDefined();
+  expect(result.object.recipe).toBeDefined();
+  expect(result.object.recipe.name).toBeDefined();
+  expect(typeof result.object.recipe.name).toBe('string');
+  expect(Array.isArray(result.object.recipe.ingredients)).toBe(true);
+  expect(Array.isArray(result.object.recipe.steps)).toBe(true);
+  expect(result.object.recipe.ingredients.length).toBeGreaterThan(0);
+  expect(result.object.recipe.steps.length).toBeGreaterThan(0);
+});
+
+it('should generate structured output with json_schema using streamObject', async () => {
+  const llmgateway = createLLMGateway({
+    apiKey: process.env.LLM_GATEWAY_API_KEY,
+    baseUrl: process.env.LLM_GATEWAY_API_BASE,
+  });
+  const model = llmgateway('gpt-4o-mini');
+
+  const result = await streamObject({
+    model,
+    schema,
+    mode: 'json',
+    prompt: 'Generate a simple recipe for pancakes.',
+  });
+
+  // Consume the stream
+  for await (const _partialObject of result.partialObjectStream) {
+    // Just consume it
+  }
+
+  const finalObject = await result.object;
+
+  expect(finalObject).toBeDefined();
+  expect(finalObject.recipe).toBeDefined();
+  expect(finalObject.recipe.name).toBeDefined();
+  expect(typeof finalObject.recipe.name).toBe('string');
+  expect(Array.isArray(finalObject.recipe.ingredients)).toBe(true);
+  expect(Array.isArray(finalObject.recipe.steps)).toBe(true);
+  expect(finalObject.recipe.ingredients.length).toBeGreaterThan(0);
+  expect(finalObject.recipe.steps.length).toBeGreaterThan(0);
+});

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -139,6 +139,23 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
     };
 
     if (responseFormat?.type === 'json') {
+      // Check if a schema is provided for structured output (json_schema)
+      if ('schema' in responseFormat && responseFormat.schema) {
+        return {
+          ...baseArgs,
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: responseFormat.schema.name || 'response',
+              description: responseFormat.schema.description,
+              schema: responseFormat.schema,
+              strict: responseFormat.schema.strict ?? true,
+            },
+          },
+        };
+      }
+
+      // Basic JSON mode (json_object)
       return {
         ...baseArgs,
         response_format: { type: 'json_object' },


### PR DESCRIPTION
Implements optional JSON schema-based structured output (`json_schema`) for chat responses. Includes tests for `generateObject` and `streamObject` to ensure proper behavior.