### PR TITLE
feat(chat): add image generation configuration support

### DIFF
--- a/e2e/image-generation.test.ts
+++ b/e2e/image-generation.test.ts
@@ -169,4 +169,106 @@ describe('image generation', () => {
       }
     }
   });
+
+  it('should generate an image with custom aspect ratio and size', async () => {
+    const llmgateway = createLLMGateway({
+      apiKey: process.env.LLM_GATEWAY_API_KEY,
+      baseUrl: process.env.LLM_GATEWAY_API_BASE,
+    });
+    const model = llmgateway('gemini-2.5-flash-image-preview', {
+      image_config: {
+        aspect_ratio: '16:9',
+        image_size: '2K',
+      },
+    });
+
+    const result = await generateText({
+      model,
+      prompt: 'Generate a wide panoramic landscape',
+    });
+
+    expect(result.text).toBeDefined();
+    expect(typeof result.text).toBe('string');
+
+    // Check for image in response messages
+    expect(result.response).toBeDefined();
+    expect(result.response.messages).toBeDefined();
+    expect(Array.isArray(result.response.messages)).toBe(true);
+
+    // Find the assistant message with image content
+    const assistantMessage = result.response.messages.find(
+      (msg: any) => msg.role === 'assistant'
+    );
+    expect(assistantMessage).toBeDefined();
+
+    // Check if content is an array before calling find
+    const imageContent = Array.isArray(assistantMessage?.content)
+      ? (assistantMessage.content.find((content) => content.type === 'file') as FilePart | undefined)
+      : undefined;
+
+    if (imageContent) {
+      expect(imageContent.mediaType).toMatch(/^image\//);
+      expect(imageContent.data).toBeDefined();
+
+      // data can be URL or DataContent (string), check if it's a string
+      if (typeof imageContent.data === 'string') {
+        expect(imageContent.data.length).toBeGreaterThan(0);
+
+        // Base64 validation - should be a valid base64 string
+        const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+        expect(base64Regex.test(imageContent.data)).toBe(true);
+      }
+    }
+  });
+
+  it('should generate an image with square aspect ratio', async () => {
+    const llmgateway = createLLMGateway({
+      apiKey: process.env.LLM_GATEWAY_API_KEY,
+      baseUrl: process.env.LLM_GATEWAY_API_BASE,
+    });
+    const model = llmgateway('gemini-2.5-flash-image-preview', {
+      image_config: {
+        aspect_ratio: '1:1',
+        image_size: '1K',
+      },
+    });
+
+    const result = await generateText({
+      model,
+      prompt: 'Generate a square portrait of a robot',
+    });
+
+    expect(result.text).toBeDefined();
+    expect(typeof result.text).toBe('string');
+
+    // Check for image in response messages
+    expect(result.response).toBeDefined();
+    expect(result.response.messages).toBeDefined();
+    expect(Array.isArray(result.response.messages)).toBe(true);
+
+    // Find the assistant message with image content
+    const assistantMessage = result.response.messages.find(
+      (msg: any) => msg.role === 'assistant'
+    );
+    expect(assistantMessage).toBeDefined();
+
+    // Check if content is an array before calling find
+    const imageContent = Array.isArray(assistantMessage?.content)
+      ? (assistantMessage.content.find((content) => content.type === 'file') as FilePart | undefined)
+      : undefined;
+
+    if (imageContent) {
+      expect(imageContent.mediaType).toMatch(/^image\//);
+      expect(imageContent.data).toBeDefined();
+
+      // data can be URL or DataContent (string), check if it's a string
+      if (typeof imageContent.data === 'string') {
+        expect(imageContent.data.length).toBeGreaterThan(0);
+
+        // Base64 validation - should be a valid base64 string
+        const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+        expect(base64Regex.test(imageContent.data)).toBe(true);
+      }
+    }
+  });
 })

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -133,6 +133,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
       include_reasoning: this.settings.includeReasoning,
       reasoning: this.settings.reasoning,
       usage: this.settings.usage,
+      image_config: this.settings.image_config,
 
       // extra body:
       ...this.config.extraBody,

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -128,6 +128,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
       // LLMGateway specific settings:
       include_reasoning: this.settings.includeReasoning,
       reasoning: this.settings.reasoning,
+      image_config: this.settings.image_config,
 
       // extra body:
       ...this.config.extraBody,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,23 @@ export type LLMGatewayProviderOptions = {
   );
 
   /**
+   * Image generation configuration for supported models (e.g., Google's image generation models).
+   * Specifies aspect ratio and image resolution for generated images.
+   */
+  image_config?: {
+    /**
+     * The aspect ratio of the generated image.
+     * Examples: "1:1", "16:9", "4:3", "5:4"
+     */
+    aspect_ratio?: string;
+    /**
+     * The resolution of the generated image.
+     * Options: "1K" (1024x1024), "2K" (2048x2048), "4K"
+     */
+    image_size?: string;
+  };
+
+  /**
    * A unique identifier representing your end-user, which can
    * help LLMGateway to monitor and detect abuse.
    */


### PR DESCRIPTION
## Summary
- Add support for LLMGateway image generation configuration options
- Enable customization of aspect ratio and image size for generated images
- Support for Google's image generation models (e.g., `gemini-2.5-flash-image-preview`)

## Changes
- **Type Definitions**: Added `image_config` to `LLMGatewayProviderOptions` with `aspect_ratio` and `image_size` parameters
- **Chat Model**: Updated to pass `image_config` to the API request
- **Completion Model**: Updated to pass `image_config` to the API request
- **Tests**: Added two new E2E tests for image generation with custom configurations (16:9 @ 2K and 1:1 @ 1K)

## Configuration Options
- `aspect_ratio`: Controls image dimensions (e.g., "1:1", "16:9", "4:3", "5:4")
- `image_size`: Sets resolution ("1K" for 1024x1024, "2K" for 2048x2048, "4K")

## Usage Example
```typescript
const llmgateway = createLLMGateway({
  apiKey: process.env.LLM_GATEWAY_API_KEY,
  baseUrl: process.env.LLM_GATEWAY_API_BASE,
});

const model = llmgateway('gemini-2.5-flash-image-preview', {
  image_config: {
    aspect_ratio: '16:9',
    image_size: '2K',
  },
});

const result = await generateText({
  model,
  prompt: 'Generate a wide panoramic landscape',
});
```

## Documentation Reference
https://docs.llmgateway.io/features/image-generation#image-configuration

## Test Plan
- [x] Added E2E tests for 16:9 aspect ratio with 2K resolution
- [x] Added E2E tests for 1:1 aspect ratio with 1K resolution
- [x] Verified configuration is passed to both chat and completion models
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)