### PR TITLE
feat(settings): add reasoning_effort parameter support

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -132,6 +132,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
       // LLMGateway specific settings:
       include_reasoning: this.settings.includeReasoning,
       reasoning: this.settings.reasoning,
+      reasoning_effort: this.settings.reasoning_effort,
       usage: this.settings.usage,
       image_config: this.settings.image_config,
 

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -128,6 +128,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
       // LLMGateway specific settings:
       include_reasoning: this.settings.includeReasoning,
       reasoning: this.settings.reasoning,
+      reasoning_effort: this.settings.reasoning_effort,
       image_config: this.settings.image_config,
 
       // extra body:

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,12 @@ export type LLMGatewaySharedSettings = LLMGatewayProviderOptions & {
    */
   includeReasoning?: boolean;
 
+  /**
+   * Reasoning effort level for models that support it.
+   * Controls the computational effort applied to reasoning tasks.
+   */
+  reasoning_effort?: 'minimal' | 'low' | 'medium' | 'high';
+
   extraBody?: Record<string, unknown>;
 
   /**


### PR DESCRIPTION
## Summary
- Added support for `reasoning_effort` parameter that accepts `'minimal' | 'low' | 'medium' | 'high' | undefined`
- This parameter controls the computational effort applied to reasoning tasks for models that support it
- Updated both chat and completion implementations to pass the parameter to the API

## Changes
- Added `reasoning_effort` property to `LLMGatewaySharedSettings` type in `src/types/index.ts`
- Updated `LLMGatewayChatLanguageModel.getArgs()` to include `reasoning_effort` in request payload
- Updated `LLMGatewayCompletionLanguageModel.getArgs()` to include `reasoning_effort` in request payload

## Test plan
- [x] TypeScript type checking passes
- [x] Build completes successfully
- [ ] Manual testing with models that support reasoning effort levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)