### PR TITLE
fix(schemas): accept cost as number or object in usage response

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -372,7 +372,10 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
                 promptTokens: usageInfo.inputTokens ?? 0,
                 completionTokens: usageInfo.outputTokens ?? 0,
                 totalTokens: usageInfo.totalTokens ?? 0,
-                cost: response.usage?.cost,
+                cost:
+                  typeof response.usage?.cost === 'number'
+                    ? response.usage.cost
+                    : response.usage?.cost?.total_cost,
                 promptTokensDetails: {
                   cachedTokens:
                     response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
@@ -539,7 +542,10 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
                 };
               }
 
-              llmgatewayUsage.cost = value.usage.cost;
+              llmgatewayUsage.cost =
+                typeof value.usage.cost === 'number'
+                  ? value.usage.cost
+                  : value.usage.cost?.total_cost;
               llmgatewayUsage.totalTokens = value.usage.total_tokens;
             }
 

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -22,7 +22,12 @@ const LLMGatewayChatCompletionBaseResponseSchema = z.object({
         })
         .nullish(),
       total_tokens: z.number(),
-      cost: z.number().optional(),
+      cost: z
+        .union([
+          z.number(),
+          z.object({ total_cost: z.number() }).passthrough(),
+        ])
+        .optional(),
       cost_details: z
         .object({
           upstream_inference_cost: z.number().nullish(),

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -295,7 +295,10 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
                 };
               }
 
-              llmgatewayUsage.cost = value.usage.cost;
+              llmgatewayUsage.cost =
+                typeof value.usage.cost === 'number'
+                  ? value.usage.cost
+                  : value.usage.cost?.total_cost;
               llmgatewayUsage.totalTokens = value.usage.total_tokens;
             }
 

--- a/src/completion/schemas.ts
+++ b/src/completion/schemas.ts
@@ -42,7 +42,12 @@ export const LLMGatewayCompletionChunkSchema = z.union([
           })
           .nullish(),
         total_tokens: z.number(),
-        cost: z.number().optional(),
+        cost: z
+          .union([
+            z.number(),
+            z.object({ total_cost: z.number() }).passthrough(),
+          ])
+          .optional(),
       })
       .nullish(),
   }),


### PR DESCRIPTION
## Summary
- Some providers (e.g. Perplexity via LLM Gateway) return `usage.cost` as an object with a cost breakdown (`{ input_tokens_cost, output_tokens_cost, request_cost, total_cost }`) instead of a plain number
- This caused a Zod `TypeValidationError` (`expected number, received object`), crashing the request despite receiving a valid 200 response
- Updated the Zod schemas in both chat and completion to accept `cost` as either a `number` or an object containing `total_cost`, and normalize the object form to its `total_cost` value at the consumption points

## Test plan
- [x] Added test case for object-format cost (Perplexity-style response)
- [x] All 69 existing + new tests pass in both Node and Edge environments
- [ ] Manual verification with `perplexity/sonar-pro` model via LLM Gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)