### PR TITLE
feat: support image editing via options.files

### DIFF
--- a/e2e/json-schema.test.ts
+++ b/e2e/json-schema.test.ts
@@ -1,6 +1,6 @@
-import { generateObject, streamObject } from 'ai';
-import { it, expect, vi } from 'vitest';
 import { createLLMGateway } from '@/src';
+import { generateObject, streamObject } from 'ai';
+import { expect, it, vi } from 'vitest';
 import { z } from 'zod/v3';
 
 vi.setConfig({
@@ -8,14 +8,20 @@ vi.setConfig({
 });
 
 const schema = z.object({
-  recipe: z.object({
-    name: z.string().describe('Name of the recipe'),
-    ingredients: z.array(z.object({
-      name: z.string().describe('Name of the ingredient'),
-      amount: z.string().describe('Amount of the ingredient'),
-    })).describe('List of ingredients'),
-    steps: z.array(z.string()).describe('Cooking steps'),
-  }).describe('Recipe details'),
+  recipe: z
+    .object({
+      name: z.string().describe('Name of the recipe'),
+      ingredients: z
+        .array(
+          z.object({
+            name: z.string().describe('Name of the ingredient'),
+            amount: z.string().describe('Amount of the ingredient'),
+          }),
+        )
+        .describe('List of ingredients'),
+      steps: z.array(z.string()).describe('Cooking steps'),
+    })
+    .describe('Recipe details'),
 });
 
 it('should generate structured output with json_schema using generateObject', async () => {

--- a/e2e/pdf-blob/index.test.ts
+++ b/e2e/pdf-blob/index.test.ts
@@ -1,9 +1,9 @@
 import type { ModelMessage } from 'ai';
 
-import { generateText } from 'ai';
 import { writeFile } from 'fs/promises';
-import { test, vi } from 'vitest';
 import { createLLMGateway } from '@/src';
+import { generateText } from 'ai';
+import { test, vi } from 'vitest';
 
 vi.setConfig({
   testTimeout: 42_000,

--- a/e2e/pdf-url/index.test.ts
+++ b/e2e/pdf-url/index.test.ts
@@ -1,9 +1,9 @@
 import type { ModelMessage } from 'ai';
 
-import { generateText } from 'ai';
 import { writeFile } from 'fs/promises';
-import { test, vi } from 'vitest';
 import { createLLMGateway } from '@/src';
+import { generateText } from 'ai';
+import { test, vi } from 'vitest';
 
 vi.setConfig({
   testTimeout: 42_000,

--- a/e2e/tools-with-reasoning.test.ts
+++ b/e2e/tools-with-reasoning.test.ts
@@ -1,13 +1,13 @@
 import type { ModelMessage } from 'ai';
 
-import { generateText } from 'ai';
-import { it, vi } from 'vitest';
 import {
   executeCommandInTerminalTool,
   readSMSTool,
   sendSMSTool,
 } from '@/e2e/tools';
 import { createLLMGateway } from '@/src';
+import { generateText } from 'ai';
+import { it, vi } from 'vitest';
 
 vi.setConfig({
   testTimeout: 42_000,

--- a/e2e/tools.ts
+++ b/e2e/tools.ts
@@ -1,8 +1,8 @@
 // ref: https://github.com/t3dotgg/SnitchScript/blob/main/tools.ts
 
+import { createLLMGateway } from '@/src';
 import { generateText, tool } from 'ai';
 import { z } from 'zod/v4';
-import { createLLMGateway } from '@/src';
 
 const llmgateway = createLLMGateway({
   apiKey: process.env.LLM_GATEWAY_API_KEY,

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -32,9 +32,12 @@ export function getFileUrl({
     : `data:${part.mediaType ?? defaultMediaType};base64,${stringUrl}`;
 }
 
-export function getMediaType(dataUrl: string, defaultMediaType: string): string {
+export function getMediaType(
+  dataUrl: string,
+  defaultMediaType: string,
+): string {
   const match = dataUrl.match(/^data:([^;]+)/);
-  return match ? match[1] ?? defaultMediaType : defaultMediaType;
+  return match ? (match[1] ?? defaultMediaType) : defaultMediaType;
 }
 
 export function getBase64FromDataUrl(dataUrl: string): string {

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1,13 +1,11 @@
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type { ImageResponse } from '../schemas/image';
 import type { ReasoningDetailUnion } from '../schemas/reasoning-details';
 
-import {
-  convertReadableStreamToArray,
-} from '@ai-sdk/provider-utils/test';
+import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 
 import { createLLMGateway } from '../provider';
 import { ReasoningDetailType } from '../schemas/reasoning-details';
-import type { ImageResponse } from '../schemas/image';
 import { createTestServer } from '../tests/create-test-server';
 
 const TEST_PROMPT: LanguageModelV2Prompt = [
@@ -109,7 +107,8 @@ const TEST_LOGPROBS = {
   ],
 };
 
-const TEST_IMAGE_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABAAAAAQACAIAAADwf7zUAAAAiXpUWHRSYXcgcHJvZmlsZSB0eXBlIGlwdGMAAAiZTYwxDgIxDAT7vOKekDjrtV1T0VHwgbtcIiEhgfh/QaDgmGlWW0w6X66n5fl6jNu9p+ULkapDENgzpj+Kl5aFfa6KnYWgSjZjGOiSYRxTY/v8KIijI==";
+const TEST_IMAGE_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABAAAAAQACAIAAADwf7zUAAAAiXpUWHRSYXcgcHJvZmlsZSB0eXBlIGlwdGMAAAiZTYwxDgIxDAT7vOKekDjrtV1T0VHwgbtcIiEhgfh/QaDgmGlWW0w6X66n5fl6jNu9p+ULkapDENgzpj+Kl5aFfa6KnYWgSjZjGOiSYRxTY/v8KIijI==';
 
 const TEST_IMAGE_BASE64 = TEST_IMAGE_URL.split(',')[1]!;
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -258,7 +258,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
 
     const reasoning: Array<LanguageModelV2Content> =
       reasoningDetails.length > 0
-        ? reasoningDetails
+        ? (reasoningDetails
             .map((detail: ReasoningDetailUnion) => {
               switch (detail.type) {
                 case ReasoningDetailType.Text: {
@@ -298,7 +298,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
             })
             .filter(
               (p): p is { type: 'reasoning'; text: string } => p !== null,
-            ) as LanguageModelV2Content[]
+            ) as LanguageModelV2Content[])
         : choice.message.reasoningText
           ? [
               {

--- a/src/chat/schemas.ts
+++ b/src/chat/schemas.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod/v4';
 
 import { LLMGatewayErrorResponseSchema } from '../schemas/error-response';
-import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
 import { ImageResponseArraySchema } from '../schemas/image';
+import { ReasoningDetailArraySchema } from '../schemas/reasoning-details';
 
 const LLMGatewayChatCompletionBaseResponseSchema = z.object({
   id: z.string().optional(),
@@ -23,10 +23,7 @@ const LLMGatewayChatCompletionBaseResponseSchema = z.object({
         .nullish(),
       total_tokens: z.number(),
       cost: z
-        .union([
-          z.number(),
-          z.object({ total_cost: z.number() }).passthrough(),
-        ])
+        .union([z.number(), z.object({ total_cost: z.number() }).passthrough()])
         .optional(),
       cost_details: z
         .object({

--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -5,9 +5,18 @@ const TEST_BASE64_IMAGE =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
 const testUrl = 'https://test.llmgateway.io/v1/images/generations';
+const testEditsUrl = 'https://test.llmgateway.io/v1/images/edits';
 
 const server = createTestServer({
   [testUrl]: {
+    response: {
+      type: 'json-value',
+      body: {
+        data: [{ b64_json: TEST_BASE64_IMAGE }],
+      },
+    },
+  },
+  [testEditsUrl]: {
     response: {
       type: 'json-value',
       body: {
@@ -213,6 +222,134 @@ describe('LLMGatewayImageModel', () => {
 
     it('should set provider to llmgateway.image', () => {
       expect(model.provider).toBe('llmgateway.image');
+    });
+
+    it('should send to /images/edits when files are provided', async () => {
+      await model.doGenerate({
+        prompt: 'add a hat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: TEST_BASE64_IMAGE,
+          },
+        ],
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      expect(server.calls[0]!.url).toBe(testEditsUrl);
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'add a hat',
+        n: 1,
+        response_format: 'b64_json',
+        images: [
+          {
+            image_url: `data:image/png;base64,${TEST_BASE64_IMAGE}`,
+          },
+        ],
+      });
+    });
+
+    it('should send to /images/edits with URL-type files', async () => {
+      await model.doGenerate({
+        prompt: 'make it blue',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [
+          {
+            type: 'url',
+            url: 'https://example.com/image.png',
+          },
+        ],
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      expect(server.calls[0]!.url).toBe(testEditsUrl);
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'make it blue',
+        n: 1,
+        response_format: 'b64_json',
+        images: [
+          {
+            image_url: 'https://example.com/image.png',
+          },
+        ],
+      });
+    });
+
+    it('should send to /images/edits with Uint8Array file data', async () => {
+      const binaryData = new Uint8Array([137, 80, 78, 71]);
+      await model.doGenerate({
+        prompt: 'edit this',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: binaryData,
+          },
+        ],
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      expect(server.calls[0]!.url).toBe(testEditsUrl);
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body.images).toEqual([
+        {
+          image_url: `data:image/png;base64,${Buffer.from(binaryData).toString('base64')}`,
+        },
+      ]);
+    });
+
+    it('should send to /images/generations when files is undefined', async () => {
+      await model.doGenerate({
+        prompt: 'a cat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      expect(server.calls[0]!.url).toBe(testUrl);
+    });
+
+    it('should send to /images/generations when files is empty', async () => {
+      await model.doGenerate({
+        prompt: 'a cat',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: [],
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      expect(server.calls[0]!.url).toBe(testUrl);
     });
   });
 });

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -3,6 +3,11 @@ import type {
   ImageModelV3CallOptions,
   SharedV3Warning,
 } from '@ai-sdk/provider';
+import type {
+  LLMGatewayImageModelId,
+  LLMGatewayImageSettings,
+} from '../types/llmgateway-image-settings';
+
 import {
   combineHeaders,
   createJsonResponseHandler,
@@ -11,10 +16,6 @@ import {
 import { z } from 'zod/v4';
 
 import { llmgatewayFailedResponseHandler } from '../schemas/error-response';
-import type {
-  LLMGatewayImageModelId,
-  LLMGatewayImageSettings,
-} from '../types/llmgateway-image-settings';
 
 type LLMGatewayImageConfig = {
   provider: string;
@@ -54,9 +55,7 @@ export class LLMGatewayImageModel implements ImageModelV3 {
     this.provider = config.provider;
   }
 
-  async doGenerate(
-    options: ImageModelV3CallOptions,
-  ): Promise<{
+  async doGenerate(options: ImageModelV3CallOptions): Promise<{
     images: Array<string>;
     warnings: Array<SharedV3Warning>;
     response: {
@@ -74,12 +73,28 @@ export class LLMGatewayImageModel implements ImageModelV3 {
       });
     }
 
+    const hasFiles = options.files != null && options.files.length > 0;
+
     const body: Record<string, unknown> = {
       model: this.modelId,
       prompt: options.prompt,
       n: options.n,
       response_format: 'b64_json',
     };
+
+    if (hasFiles) {
+      body.images = options.files!.map((file) => {
+        if (file.type === 'url') {
+          return { image_url: file.url };
+        }
+        const base64 =
+          typeof file.data === 'string'
+            ? file.data
+            : Buffer.from(file.data).toString('base64');
+        const mediaType = file.mediaType ?? 'image/png';
+        return { image_url: `data:${mediaType};base64,${base64}` };
+      });
+    }
 
     if (options.size != null) {
       body.size = options.size;
@@ -91,7 +106,7 @@ export class LLMGatewayImageModel implements ImageModelV3 {
 
     const { value: response, responseHeaders } = await postJsonToApi({
       url: this.config.url({
-        path: '/images/generations',
+        path: hasFiles ? '/images/edits' : '/images/generations',
         modelId: this.modelId,
       }),
       headers: combineHeaders(this.config.headers(), options.headers),

--- a/src/tests/create-test-server.ts
+++ b/src/tests/create-test-server.ts
@@ -27,7 +27,9 @@ export type TestServer = {
   fetch: typeof fetch;
 };
 
-function toHeadersRecord(headers: HeadersInit | undefined): Record<string, string> {
+function toHeadersRecord(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
   if (!headers) return {};
 
   if (headers instanceof Headers) {
@@ -61,7 +63,9 @@ function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
  * - `server.calls[]` for request inspection
  * - `server.fetch` to inject into provider options (`createLLMGateway({ fetch: server.fetch })`)
  */
-export function createTestServer(urls: Record<string, TestServerUrlConfig>): TestServer {
+export function createTestServer(
+  urls: Record<string, TestServerUrlConfig>,
+): TestServer {
   const calls: TestServerCall[] = [];
 
   const testFetch: typeof fetch = async (input, init) => {
@@ -122,5 +126,3 @@ export function createTestServer(urls: Record<string, TestServerUrlConfig>): Tes
 
   return { urls, calls, fetch: testFetch };
 }
-
-

--- a/src/tests/usage-accounting.test.ts
+++ b/src/tests/usage-accounting.test.ts
@@ -137,9 +137,7 @@ describe('LLMGateway Usage Accounting', () => {
   });
 
   it('should normalize cost when returned as an object (e.g. Perplexity models)', async () => {
-    server.urls[
-      'https://api.llmgateway.io/v1/chat/completions'
-    ]!.response = {
+    server.urls['https://api.llmgateway.io/v1/chat/completions']!.response = {
       type: 'json-value',
       body: {
         id: 'test-id',


### PR DESCRIPTION
## Summary
- Updated `LLMGatewayImageModel.doGenerate()` to handle `options.files` from the Vercel AI SDK
- When files are present, includes them as `images` in the request body and routes to `/images/edits` instead of `/images/generations`
- Supports both `file` type (base64 string or Uint8Array) and `url` type files

This enables `generateImage()` with structured prompts for image editing:
```typescript
const result = await generateImage({
  model: llmgateway.image('qwen-image-edit-plus'),
  prompt: { images: [inputImageData], text: 'add a watercolor effect' },
});
```

## Test plan
- [x] Added 5 new unit tests for image editing scenarios
- [x] All 84 tests pass in both Node and Edge environments
- [ ] Test locally with gateway at localhost:4001

🤖 Generated with [Claude Code](https://claude.com/claude-code)