### PR TITLE
feat!: migrate from LanguageModelV2 to LanguageModelV3

### DIFF
--- a/src/chat/convert-to-llmgateway-chat-messages.ts
+++ b/src/chat/convert-to-llmgateway-chat-messages.ts
@@ -1,10 +1,10 @@
 import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 import type {
-  LanguageModelV2FilePart,
-  LanguageModelV2Prompt,
-  LanguageModelV2TextPart,
-  LanguageModelV2ToolResultPart,
-  SharedV2ProviderMetadata,
+  LanguageModelV3FilePart,
+  LanguageModelV3Prompt,
+  LanguageModelV3TextPart,
+  LanguageModelV3ToolResultPart,
+  SharedV3ProviderOptions,
 } from '@ai-sdk/provider';
 import type {
   ChatCompletionContentPart,
@@ -20,7 +20,7 @@ import { isUrl } from './is-url';
 export type LLMGatewayCacheControl = { type: 'ephemeral' };
 
 function getCacheControl(
-  providerOptions: SharedV2ProviderMetadata | undefined,
+  providerOptions: SharedV3ProviderOptions | undefined,
 ): LLMGatewayCacheControl | undefined {
   const anthropic = providerOptions?.anthropic;
   const llmgateway = providerOptions?.llmgateway;
@@ -33,7 +33,7 @@ function getCacheControl(
 }
 
 export function convertToLLMGatewayChatMessages(
-  prompt: LanguageModelV2Prompt,
+  prompt: LanguageModelV3Prompt,
 ): LLMGatewayChatCompletionsInput {
   const messages: LLMGatewayChatCompletionsInput = [];
   for (const { role, content, providerOptions } of prompt) {
@@ -72,7 +72,7 @@ export function convertToLLMGatewayChatMessages(
         // Get message level cache control
         const messageCacheControl = getCacheControl(providerOptions);
         const contentParts: ChatCompletionContentPart[] = content.map(
-          (part: LanguageModelV2TextPart | LanguageModelV2FilePart) => {
+          (part: LanguageModelV3TextPart | LanguageModelV3FilePart) => {
             const cacheControl =
               getCacheControl(part.providerOptions) ?? messageCacheControl;
 
@@ -215,6 +215,7 @@ export function convertToLLMGatewayChatMessages(
 
       case 'tool': {
         for (const toolResponse of content) {
+          if (toolResponse.type !== 'tool-result') continue;
           const content = getToolResultContent(toolResponse);
 
           messages.push({
@@ -238,8 +239,13 @@ export function convertToLLMGatewayChatMessages(
   return messages;
 }
 
-function getToolResultContent(input: LanguageModelV2ToolResultPart): string {
-  return input.output.type === 'text'
-    ? input.output.value
-    : JSON.stringify(input.output.value);
+function getToolResultContent(input: LanguageModelV3ToolResultPart): string {
+  switch (input.output.type) {
+    case 'text':
+      return input.output.value;
+    case 'json':
+      return JSON.stringify(input.output.value);
+    default:
+      return JSON.stringify(input.output);
+  }
 }

--- a/src/chat/file-url-utils.ts
+++ b/src/chat/file-url-utils.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2FilePart } from '@ai-sdk/provider';
+import type { LanguageModelV3FilePart } from '@ai-sdk/provider';
 
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils';
 
@@ -8,7 +8,7 @@ export function getFileUrl({
   part,
   defaultMediaType,
 }: {
-  part: LanguageModelV2FilePart;
+  part: LanguageModelV3FilePart;
   defaultMediaType: string;
 }) {
   if (part.data instanceof Uint8Array) {

--- a/src/chat/get-tool-choice.ts
+++ b/src/chat/get-tool-choice.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2ToolChoice } from '@ai-sdk/provider';
+import type { LanguageModelV3ToolChoice } from '@ai-sdk/provider';
 
 import { z } from 'zod/v4';
 
@@ -17,7 +17,7 @@ const ChatCompletionToolChoiceSchema = z.union([
 type ChatCompletionToolChoice = z.infer<typeof ChatCompletionToolChoiceSchema>;
 
 export function getChatCompletionToolChoice(
-  toolChoice: LanguageModelV2ToolChoice,
+  toolChoice: LanguageModelV3ToolChoice,
 ): ChatCompletionToolChoice {
   switch (toolChoice.type) {
     case 'auto':

--- a/src/chat/index.test.ts
+++ b/src/chat/index.test.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
 import type { ImageResponse } from '../schemas/image';
 import type { ReasoningDetailUnion } from '../schemas/reasoning-details';
 
@@ -8,7 +8,7 @@ import { createLLMGateway } from '../provider';
 import { ReasoningDetailType } from '../schemas/reasoning-details';
 import { createTestServer } from '../tests/create-test-server';
 
-const TEST_PROMPT: LanguageModelV2Prompt = [
+const TEST_PROMPT: LanguageModelV3Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -215,11 +215,17 @@ describe('doGenerate', () => {
     });
 
     expect(usage).toStrictEqual({
-      inputTokens: 20,
-      outputTokens: 5,
-      totalTokens: 25,
-      reasoningTokens: 0,
-      cachedInputTokens: 0,
+      inputTokens: {
+        total: 20,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 5,
+        text: undefined,
+        reasoning: undefined,
+      },
     });
   });
 
@@ -243,7 +249,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(response.finishReason).toStrictEqual('stop');
+    expect(response.finishReason).toStrictEqual({ unified: 'stop', raw: 'stop' });
   });
 
   it('should support unknown finish reason', async () => {
@@ -256,7 +262,7 @@ describe('doGenerate', () => {
       prompt: TEST_PROMPT,
     });
 
-    expect(response.finishReason).toStrictEqual('unknown');
+    expect(response.finishReason).toStrictEqual({ unified: 'other', raw: 'eos' });
   });
 
   it('should extract reasoning content from reasoning field', async () => {
@@ -843,7 +849,7 @@ describe('doStream', () => {
       },
       {
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
 
         providerMetadata: {
           llmgateway: {
@@ -856,11 +862,17 @@ describe('doStream', () => {
           },
         },
         usage: {
-          inputTokens: 17,
-          outputTokens: 227,
-          totalTokens: 244,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: 17,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 227,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -1128,7 +1140,7 @@ describe('doStream', () => {
       },
       {
         type: 'finish',
-        finishReason: 'tool-calls',
+        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
         providerMetadata: {
           llmgateway: {
             usage: {
@@ -1140,11 +1152,17 @@ describe('doStream', () => {
           },
         },
         usage: {
-          inputTokens: 53,
-          outputTokens: 17,
-          totalTokens: 70,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: 53,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 17,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -1231,7 +1249,7 @@ describe('doStream', () => {
       },
       {
         type: 'finish',
-        finishReason: 'tool-calls',
+        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
         providerMetadata: {
           llmgateway: {
             usage: {
@@ -1243,11 +1261,17 @@ describe('doStream', () => {
           },
         },
         usage: {
-          inputTokens: 53,
-          outputTokens: 17,
-          totalTokens: 70,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: 53,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 17,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -1308,7 +1332,7 @@ describe('doStream', () => {
       },
       {
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         providerMetadata: {
           llmgateway: {
             usage: {
@@ -1320,11 +1344,17 @@ describe('doStream', () => {
           },
         },
         usage: {
-          inputTokens: 53,
-          outputTokens: 17,
-          totalTokens: 70,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: 53,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 17,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -1358,7 +1388,7 @@ describe('doStream', () => {
         },
       },
       {
-        finishReason: 'error',
+        finishReason: { unified: 'error', raw: undefined },
         providerMetadata: {
           llmgateway: {
             usage: {},
@@ -1366,11 +1396,17 @@ describe('doStream', () => {
         },
         type: 'finish',
         usage: {
-          inputTokens: Number.NaN,
-          outputTokens: Number.NaN,
-          totalTokens: Number.NaN,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: undefined,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: undefined,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -1391,7 +1427,7 @@ describe('doStream', () => {
     expect(elements.length).toBe(2);
     expect(elements[0]?.type).toBe('error');
     expect(elements[1]).toStrictEqual({
-      finishReason: 'error',
+      finishReason: { unified: 'error', raw: undefined },
 
       type: 'finish',
       providerMetadata: {
@@ -1400,11 +1436,17 @@ describe('doStream', () => {
         },
       },
       usage: {
-        inputTokens: Number.NaN,
-        outputTokens: Number.NaN,
-        totalTokens: Number.NaN,
-        reasoningTokens: Number.NaN,
-        cachedInputTokens: Number.NaN,
+        inputTokens: {
+          total: undefined,
+          noCache: undefined,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: undefined,
+          text: undefined,
+          reasoning: undefined,
+        },
       },
     });
   });

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -2,15 +2,14 @@ import type { z } from 'zod/v4';
 import type { ReasoningDetailUnion } from '@/src/schemas/reasoning-details';
 import type { LLMGatewayUsageAccounting } from '@/src/types/index';
 import type {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2CallWarning,
-  LanguageModelV2Content,
-  LanguageModelV2FinishReason,
-  LanguageModelV2ResponseMetadata,
-  LanguageModelV2StreamPart,
-  LanguageModelV2Usage,
-  SharedV2Headers,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3StreamResult,
+  LanguageModelV3Usage,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type {
@@ -48,10 +47,9 @@ type LLMGatewayChatConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
-  readonly specificationVersion = 'v2' as const;
+export class LLMGatewayChatLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = 'v3' as const;
   readonly provider = 'llmgateway';
-  readonly defaultObjectGenerationMode = 'tool' as const;
 
   readonly modelId: LLMGatewayChatModelId;
   readonly supportedUrls: Record<string, RegExp[]> = {
@@ -89,7 +87,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
     topK,
     tools,
     toolChoice,
-  }: LanguageModelV2CallOptions) {
+  }: LanguageModelV3CallOptions) {
     const baseArgs = {
       // model id:
       model: this.modelId,
@@ -187,22 +185,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
     return baseArgs;
   }
 
-  async doGenerate(options: LanguageModelV2CallOptions): Promise<{
-    content: Array<LanguageModelV2Content>;
-    finishReason: LanguageModelV2FinishReason;
-    usage: LanguageModelV2Usage;
-    warnings: Array<LanguageModelV2CallWarning>;
-    providerMetadata?: {
-      llmgateway: {
-        usage: LLMGatewayUsageAccounting;
-      };
-    };
-    request?: { body?: unknown };
-    response?: LanguageModelV2ResponseMetadata & {
-      headers?: SharedV2Headers;
-      body?: unknown;
-    };
-  }> {
+  async doGenerate(options: LanguageModelV3CallOptions): Promise<LanguageModelV3GenerateResult> {
     const providerOptions = options.providerOptions || {};
     const llmgatewayOptions = providerOptions.llmgateway || {};
 
@@ -234,29 +217,40 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
     }
 
     // Extract detailed usage information
-    const usageInfo: LanguageModelV2Usage = response.usage
+    const usageInfo: LanguageModelV3Usage = response.usage
       ? {
-          inputTokens: response.usage.prompt_tokens ?? 0,
-          outputTokens: response.usage.completion_tokens ?? 0,
-          totalTokens:
-            (response.usage.prompt_tokens ?? 0) +
-            (response.usage.completion_tokens ?? 0),
-          reasoningTokens:
-            response.usage.completion_tokens_details?.reasoning_tokens ?? 0,
-          cachedInputTokens:
-            response.usage.prompt_tokens_details?.cached_tokens ?? 0,
+          inputTokens: {
+            total: response.usage.prompt_tokens ?? undefined,
+            noCache: undefined,
+            cacheRead:
+              response.usage.prompt_tokens_details?.cached_tokens ?? undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: response.usage.completion_tokens ?? undefined,
+            text: undefined,
+            reasoning:
+              response.usage.completion_tokens_details?.reasoning_tokens ??
+              undefined,
+          },
         }
       : {
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-          reasoningTokens: 0,
-          cachedInputTokens: 0,
+          inputTokens: {
+            total: undefined,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: undefined,
+            text: undefined,
+            reasoning: undefined,
+          },
         };
 
     const reasoningDetails = choice.message.reasoning_details ?? [];
 
-    const reasoning: Array<LanguageModelV2Content> =
+    const reasoning: Array<LanguageModelV3Content> =
       reasoningDetails.length > 0
         ? (reasoningDetails
             .map((detail: ReasoningDetailUnion) => {
@@ -297,8 +291,8 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
               return null;
             })
             .filter(
-              (p): p is { type: 'reasoning'; text: string } => p !== null,
-            ) as LanguageModelV2Content[])
+              (p: { type: 'reasoning'; text: string } | null): p is { type: 'reasoning'; text: string } => p !== null,
+            ) as LanguageModelV3Content[])
         : choice.message.reasoningText
           ? [
               {
@@ -308,7 +302,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
             ]
           : [];
 
-    const content: Array<LanguageModelV2Content> = [];
+    const content: Array<LanguageModelV3Content> = [];
 
     // Add reasoning content first
     content.push(...reasoning);
@@ -369,9 +363,11 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
         ? {
             llmgateway: {
               usage: {
-                promptTokens: usageInfo.inputTokens ?? 0,
-                completionTokens: usageInfo.outputTokens ?? 0,
-                totalTokens: usageInfo.totalTokens ?? 0,
+                promptTokens: usageInfo.inputTokens.total ?? 0,
+                completionTokens: usageInfo.outputTokens.total ?? 0,
+                totalTokens:
+                  (usageInfo.inputTokens.total ?? 0) +
+                  (usageInfo.outputTokens.total ?? 0),
                 cost:
                   typeof response.usage?.cost === 'number'
                     ? response.usage.cost
@@ -402,15 +398,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
     };
   }
 
-  async doStream(options: LanguageModelV2CallOptions): Promise<{
-    stream: ReadableStream<LanguageModelV2StreamPart>;
-    warnings: Array<LanguageModelV2CallWarning>;
-    request?: { body?: unknown };
-    response?: LanguageModelV2ResponseMetadata & {
-      headers?: SharedV2Headers;
-      body?: unknown;
-    };
-  }> {
+  async doStream(options: LanguageModelV3CallOptions): Promise<LanguageModelV3StreamResult> {
     const providerOptions = options.providerOptions || {};
     const llmgatewayOptions = providerOptions.llmgateway || {};
 
@@ -454,13 +442,19 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
       sent: boolean;
     }> = [];
 
-    let finishReason: LanguageModelV2FinishReason = 'other';
-    const usage: LanguageModelV2Usage = {
-      inputTokens: Number.NaN,
-      outputTokens: Number.NaN,
-      totalTokens: Number.NaN,
-      reasoningTokens: Number.NaN,
-      cachedInputTokens: Number.NaN,
+    let finishReason: LanguageModelV3FinishReason = { unified: 'other', raw: undefined };
+    const usage: LanguageModelV3Usage = {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
     };
 
     // Track provider-specific usage information
@@ -478,12 +472,12 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
           ParseResult<
             z.infer<typeof LLMGatewayStreamChatCompletionChunkSchema>
           >,
-          LanguageModelV2StreamPart
+          LanguageModelV3StreamPart
         >({
           transform(chunk, controller) {
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
-              finishReason = 'error';
+              finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({ type: 'error', error: chunk.error });
               return;
             }
@@ -492,7 +486,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
 
             // handle error chunks:
             if ('error' in value) {
-              finishReason = 'error';
+              finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({ type: 'error', error: value.error });
               return;
             }
@@ -513,10 +507,8 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
             }
 
             if (value.usage != null) {
-              usage.inputTokens = value.usage.prompt_tokens;
-              usage.outputTokens = value.usage.completion_tokens;
-              usage.totalTokens =
-                value.usage.prompt_tokens + value.usage.completion_tokens;
+              usage.inputTokens.total = value.usage.prompt_tokens;
+              usage.outputTokens.total = value.usage.completion_tokens;
 
               // Collect LLMGateway specific usage information
               llmgatewayUsage.promptTokens = value.usage.prompt_tokens;
@@ -525,7 +517,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
                 const cachedInputTokens =
                   value.usage.prompt_tokens_details.cached_tokens ?? 0;
 
-                usage.cachedInputTokens = cachedInputTokens;
+                usage.inputTokens.cacheRead = cachedInputTokens;
                 llmgatewayUsage.promptTokensDetails = {
                   cachedTokens: cachedInputTokens,
                 };
@@ -536,7 +528,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
                 const reasoningTokens =
                   value.usage.completion_tokens_details.reasoning_tokens ?? 0;
 
-                usage.reasoningTokens = reasoningTokens;
+                usage.outputTokens.reasoning = reasoningTokens;
                 llmgatewayUsage.completionTokensDetails = {
                   reasoningTokens,
                 };
@@ -776,7 +768,7 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
 
           flush(controller) {
             // Forward any unsent tool calls if finish reason is 'tool-calls'
-            if (finishReason === 'tool-calls') {
+            if (finishReason.unified === 'tool-calls') {
               for (const toolCall of toolCalls) {
                 if (toolCall && !toolCall.sent) {
                   controller.enqueue({
@@ -819,7 +811,6 @@ export class LLMGatewayChatLanguageModel implements LanguageModelV2 {
           },
         }),
       ),
-      warnings: [],
       request: { body: args },
       response: { headers: responseHeaders },
     };

--- a/src/completion/convert-to-llmgateway-completion-prompt.ts
+++ b/src/completion/convert-to-llmgateway-completion-prompt.ts
@@ -1,10 +1,10 @@
 import type {
-  LanguageModelV2FilePart,
-  LanguageModelV2Prompt,
-  LanguageModelV2ReasoningPart,
-  LanguageModelV2TextPart,
-  LanguageModelV2ToolCallPart,
-  LanguageModelV2ToolResultPart,
+  LanguageModelV3FilePart,
+  LanguageModelV3Prompt,
+  LanguageModelV3ReasoningPart,
+  LanguageModelV3TextPart,
+  LanguageModelV3ToolCallPart,
+  LanguageModelV3ToolResultPart,
 } from '@ai-sdk/provider';
 
 import {
@@ -18,7 +18,7 @@ export function convertToLLMGatewayCompletionPrompt({
   user = 'user',
   assistant = 'assistant',
 }: {
-  prompt: LanguageModelV2Prompt;
+  prompt: LanguageModelV3Prompt;
   inputFormat: 'prompt' | 'messages';
   user?: string;
   assistant?: string;
@@ -58,7 +58,7 @@ export function convertToLLMGatewayCompletionPrompt({
 
       case 'user': {
         const userMessage = content
-          .map((part: LanguageModelV2TextPart | LanguageModelV2FilePart) => {
+          .map((part: LanguageModelV3TextPart | LanguageModelV3FilePart) => {
             switch (part.type) {
               case 'text': {
                 return part.text;
@@ -85,11 +85,11 @@ export function convertToLLMGatewayCompletionPrompt({
           .map(
             (
               part:
-                | LanguageModelV2TextPart
-                | LanguageModelV2FilePart
-                | LanguageModelV2ReasoningPart
-                | LanguageModelV2ToolCallPart
-                | LanguageModelV2ToolResultPart,
+                | LanguageModelV3TextPart
+                | LanguageModelV3FilePart
+                | LanguageModelV3ReasoningPart
+                | LanguageModelV3ToolCallPart
+                | LanguageModelV3ToolResultPart,
             ) => {
               switch (part.type) {
                 case 'text': {

--- a/src/completion/index.test.ts
+++ b/src/completion/index.test.ts
@@ -1,11 +1,11 @@
-import type { LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV3Prompt } from '@ai-sdk/provider';
 
 import { convertReadableStreamToArray } from '@ai-sdk/provider-utils/test';
 
 import { createLLMGateway } from '../provider';
 import { createTestServer } from '../tests/create-test-server';
 
-const TEST_PROMPT: LanguageModelV2Prompt = [
+const TEST_PROMPT: LanguageModelV3Prompt = [
   { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
 ];
 
@@ -121,11 +121,17 @@ describe('doGenerate', () => {
     });
 
     expect(usage).toStrictEqual({
-      inputTokens: 20,
-      outputTokens: 5,
-      totalTokens: 25,
-      reasoningTokens: 0,
-      cachedInputTokens: 0,
+      inputTokens: {
+        total: 20,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: 5,
+        text: undefined,
+        reasoning: undefined,
+      },
     });
   });
 
@@ -157,7 +163,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-    expect(finishReason).toStrictEqual('stop');
+    expect(finishReason).toStrictEqual({ unified: 'stop', raw: 'stop' });
   });
 
   it('should support unknown finish reason', async () => {
@@ -172,7 +178,7 @@ describe('doGenerate', () => {
         prompt: TEST_PROMPT,
       });
 
-    expect(finishReason).toStrictEqual('unknown');
+    expect(finishReason).toStrictEqual({ unified: 'other', raw: 'eos' });
   });
 
   it('should pass the model and the prompt', async () => {
@@ -321,7 +327,7 @@ describe('doStream', () => {
       { type: 'text-delta', delta: '', id: expect.any(String) },
       {
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         providerMetadata: {
           llmgateway: {
             usage: {
@@ -333,11 +339,17 @@ describe('doStream', () => {
           },
         },
         usage: {
-          inputTokens: 10,
-          outputTokens: 362,
-          totalTokens: 372,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: 10,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 362,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -371,7 +383,7 @@ describe('doStream', () => {
         },
       },
       {
-        finishReason: 'error',
+        finishReason: { unified: 'error', raw: undefined },
         providerMetadata: {
           llmgateway: {
             usage: {},
@@ -379,11 +391,17 @@ describe('doStream', () => {
         },
         type: 'finish',
         usage: {
-          inputTokens: Number.NaN,
-          outputTokens: Number.NaN,
-          totalTokens: Number.NaN,
-          reasoningTokens: Number.NaN,
-          cachedInputTokens: Number.NaN,
+          inputTokens: {
+            total: undefined,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: undefined,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       },
     ]);
@@ -404,7 +422,7 @@ describe('doStream', () => {
     expect(elements.length).toBe(2);
     expect(elements[0]?.type).toBe('error');
     expect(elements[1]).toStrictEqual({
-      finishReason: 'error',
+      finishReason: { unified: 'error', raw: undefined },
       providerMetadata: {
         llmgateway: {
           usage: {},
@@ -412,11 +430,17 @@ describe('doStream', () => {
       },
       type: 'finish',
       usage: {
-        inputTokens: Number.NaN,
-        outputTokens: Number.NaN,
-        totalTokens: Number.NaN,
-        reasoningTokens: Number.NaN,
-        cachedInputTokens: Number.NaN,
+        inputTokens: {
+          total: undefined,
+          noCache: undefined,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: undefined,
+          text: undefined,
+          reasoning: undefined,
+        },
       },
     });
   });

--- a/src/completion/index.ts
+++ b/src/completion/index.ts
@@ -1,11 +1,11 @@
 import type { z } from 'zod/v4';
 import type { LLMGatewayChatModelId } from '@/src/types/llmgateway-chat-settings';
 import type {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2FinishReason,
-  LanguageModelV2StreamPart,
-  LanguageModelV2Usage,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3FinishReason,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
 } from '@ai-sdk/provider';
 import type { ParseResult } from '@ai-sdk/provider-utils';
 import type { LLMGatewayUsageAccounting } from '../types';
@@ -34,8 +34,8 @@ type LLMGatewayCompletionConfig = {
   extraBody?: Record<string, unknown>;
 };
 
-export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
-  readonly specificationVersion = 'v2' as const;
+export class LLMGatewayCompletionLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = 'v3' as const;
   readonly provider = 'llmgateway';
   readonly modelId: LLMGatewayChatModelId;
   readonly supportedUrls: Record<string, RegExp[]> = {
@@ -46,7 +46,6 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
     'text/*': [/^data:text\//, /^https?:\/\/.+$/],
     'application/*': [/^data:application\//, /^https?:\/\/.+$/],
   };
-  readonly defaultObjectGenerationMode = undefined;
   readonly settings: LLMGatewayCompletionSettings;
 
   private readonly config: LLMGatewayCompletionConfig;
@@ -74,7 +73,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
     stopSequences,
     tools,
     toolChoice,
-  }: LanguageModelV2CallOptions) {
+  }: LanguageModelV3CallOptions) {
     const { prompt: completionPrompt } = convertToLLMGatewayCompletionPrompt({
       prompt,
       inputFormat: 'prompt',
@@ -136,8 +135,8 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
   }
 
   async doGenerate(
-    options: LanguageModelV2CallOptions,
-  ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
+    options: LanguageModelV3CallOptions,
+  ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
     const providerOptions = options.providerOptions || {};
     const llmgatewayOptions = providerOptions.llmgateway || {};
 
@@ -180,15 +179,20 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
       ],
       finishReason: mapLLMGatewayFinishReason(choice.finish_reason),
       usage: {
-        inputTokens: response.usage?.prompt_tokens ?? 0,
-        outputTokens: response.usage?.completion_tokens ?? 0,
-        totalTokens:
-          (response.usage?.prompt_tokens ?? 0) +
-          (response.usage?.completion_tokens ?? 0),
-        reasoningTokens:
-          response.usage?.completion_tokens_details?.reasoning_tokens ?? 0,
-        cachedInputTokens:
-          response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+        inputTokens: {
+          total: response.usage?.prompt_tokens ?? undefined,
+          noCache: undefined,
+          cacheRead:
+            response.usage?.prompt_tokens_details?.cached_tokens ?? undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: response.usage?.completion_tokens ?? undefined,
+          text: undefined,
+          reasoning:
+            response.usage?.completion_tokens_details?.reasoning_tokens ??
+            undefined,
+        },
       },
       warnings: [],
       response: {
@@ -198,8 +202,8 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
   }
 
   async doStream(
-    options: LanguageModelV2CallOptions,
-  ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
+    options: LanguageModelV3CallOptions,
+  ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
     const providerOptions = options.providerOptions || {};
     const llmgatewayOptions = providerOptions.llmgateway || {};
 
@@ -232,13 +236,19 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
       fetch: this.config.fetch,
     });
 
-    let finishReason: LanguageModelV2FinishReason = 'other';
-    const usage: LanguageModelV2Usage = {
-      inputTokens: Number.NaN,
-      outputTokens: Number.NaN,
-      totalTokens: Number.NaN,
-      reasoningTokens: Number.NaN,
-      cachedInputTokens: Number.NaN,
+    let finishReason: LanguageModelV3FinishReason = { unified: 'other', raw: undefined };
+    const usage: LanguageModelV3Usage = {
+      inputTokens: {
+        total: undefined,
+        noCache: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+      },
+      outputTokens: {
+        total: undefined,
+        text: undefined,
+        reasoning: undefined,
+      },
     };
 
     const llmgatewayUsage: Partial<LLMGatewayUsageAccounting> = {};
@@ -246,12 +256,12 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<z.infer<typeof LLMGatewayCompletionChunkSchema>>,
-          LanguageModelV2StreamPart
+          LanguageModelV3StreamPart
         >({
           transform(chunk, controller) {
             // handle failed chunk parsing / validation:
             if (!chunk.success) {
-              finishReason = 'error';
+              finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({ type: 'error', error: chunk.error });
               return;
             }
@@ -260,16 +270,14 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
 
             // handle error chunks:
             if ('error' in value) {
-              finishReason = 'error';
+              finishReason = { unified: 'error', raw: undefined };
               controller.enqueue({ type: 'error', error: value.error });
               return;
             }
 
             if (value.usage != null) {
-              usage.inputTokens = value.usage.prompt_tokens;
-              usage.outputTokens = value.usage.completion_tokens;
-              usage.totalTokens =
-                value.usage.prompt_tokens + value.usage.completion_tokens;
+              usage.inputTokens.total = value.usage.prompt_tokens;
+              usage.outputTokens.total = value.usage.completion_tokens;
 
               // Collect LLMGateway specific usage information
               llmgatewayUsage.promptTokens = value.usage.prompt_tokens;
@@ -278,7 +286,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
                 const cachedInputTokens =
                   value.usage.prompt_tokens_details.cached_tokens ?? 0;
 
-                usage.cachedInputTokens = cachedInputTokens;
+                usage.inputTokens.cacheRead = cachedInputTokens;
                 llmgatewayUsage.promptTokensDetails = {
                   cachedTokens: cachedInputTokens,
                 };
@@ -289,7 +297,7 @@ export class LLMGatewayCompletionLanguageModel implements LanguageModelV2 {
                 const reasoningTokens =
                   value.usage.completion_tokens_details.reasoning_tokens ?? 0;
 
-                usage.reasoningTokens = reasoningTokens;
+                usage.outputTokens.reasoning = reasoningTokens;
                 llmgatewayUsage.completionTokensDetails = {
                   reasoningTokens,
                 };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import type { ImageModelV3, LanguageModelV2 } from '@ai-sdk/provider';
+import type { ImageModelV3 } from '@ai-sdk/provider';
 import type {
   LLMGatewayChatModelId,
   LLMGatewayChatSettings,
@@ -17,7 +17,7 @@ import { LLMGatewayImageModel } from './image';
 
 export type { LLMGatewayCompletionSettings };
 
-export interface LLMGatewayProvider extends LanguageModelV2 {
+export interface LLMGatewayProvider {
   (
     modelId: LLMGatewayChatModelId,
     settings?: LLMGatewayCompletionSettings,

--- a/src/tests/stream-usage-accounting.test.ts
+++ b/src/tests/stream-usage-accounting.test.ts
@@ -164,7 +164,7 @@ describe('LLMGateway Streaming Usage Accounting', () => {
     expect(finishChunk).toBeDefined();
 
     // Verify that provider metadata is not included
-    expect(finishChunk?.providerMetadata?.llmgateway).toStrictEqual({
+    expect((finishChunk?.providerMetadata as any)?.llmgateway).toStrictEqual({
       usage: {},
     });
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-import type { LanguageModelV2, LanguageModelV2Prompt } from '@ai-sdk/provider';
+import type { LanguageModelV3, LanguageModelV3Prompt } from '@ai-sdk/provider';
 
-export type { LanguageModelV2, LanguageModelV2Prompt };
+export type { LanguageModelV3, LanguageModelV3Prompt };
 
 export type LLMGatewayProviderOptions = {
   models?: string[];

--- a/src/utils/map-finish-reason.ts
+++ b/src/utils/map-finish-reason.ts
@@ -1,19 +1,19 @@
-import type { LanguageModelV2FinishReason } from '@ai-sdk/provider';
+import type { LanguageModelV3FinishReason } from '@ai-sdk/provider';
 
 export function mapLLMGatewayFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV2FinishReason {
+): LanguageModelV3FinishReason {
   switch (finishReason) {
     case 'stop':
-      return 'stop';
+      return { unified: 'stop', raw: finishReason };
     case 'length':
-      return 'length';
+      return { unified: 'length', raw: finishReason };
     case 'content_filter':
-      return 'content-filter';
+      return { unified: 'content-filter', raw: finishReason };
     case 'function_call':
     case 'tool_calls':
-      return 'tool-calls';
+      return { unified: 'tool-calls', raw: finishReason };
     default:
-      return 'unknown';
+      return { unified: 'other', raw: finishReason ?? undefined };
   }
 }


### PR DESCRIPTION
## Summary
- Migrates the entire provider from AI SDK V2 spec to V3 spec (`specificationVersion: 'v3'`)
- Finish reason changed from string to `{ unified, raw }` object
- Usage changed from flat to nested format (`inputTokens.total`, `outputTokens.reasoning`, etc.)
- All V2 type imports replaced with V3 equivalents
- Provider interface no longer extends `LanguageModelV2`
- Tool result handling updated for V3's `ToolApprovalResponsePart` and expanded output types

## Motivation
Consumers like [opencode](https://github.com/nicepkg/opencode) require `LanguageModelV3` from their bundled providers. Currently they need a workaround adapter with `any` casts because `@llmgateway/ai-sdk-provider` implements V2. This PR fixes that — `createLLMGateway().languageModel()` now returns `LanguageModelV3` directly.

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `pnpm run build` succeeds
- [x] All 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)