### PR TITLE
feat: add image quality and extra body options

### DIFF
--- a/src/image/index.test.ts
+++ b/src/image/index.test.ts
@@ -125,6 +125,119 @@ describe('LLMGatewayImageModel', () => {
       });
     });
 
+    it('should send quality in body when provided', async () => {
+      await model.doGenerate({
+        prompt: 'a detailed landscape',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        quality: 'high',
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'a detailed landscape',
+        n: 1,
+        response_format: 'b64_json',
+        quality: 'high',
+      });
+    });
+
+    it('should include extraBody from provider settings', async () => {
+      const extraBodyProvider = createLLMGateway({
+        apiKey: 'test-api-key',
+        baseURL: 'https://test.llmgateway.io/v1',
+        compatibility: 'strict',
+        fetch: server.fetch,
+        extraBody: {
+          watermark: false,
+        },
+      });
+
+      await extraBodyProvider.image('qwen-image-plus').doGenerate({
+        prompt: 'a logo',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'a logo',
+        n: 1,
+        response_format: 'b64_json',
+        watermark: false,
+      });
+    });
+
+    it('should include extraBody from image model settings', async () => {
+      const extraBodyModel = provider.image('qwen-image-plus', {
+        extraBody: {
+          negative_prompt: 'blurry',
+        },
+      });
+
+      await extraBodyModel.doGenerate({
+        prompt: 'a portrait',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {},
+        headers: {},
+      });
+
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'a portrait',
+        n: 1,
+        response_format: 'b64_json',
+        negative_prompt: 'blurry',
+      });
+    });
+
+    it('should include llmgateway providerOptions in body', async () => {
+      await model.doGenerate({
+        prompt: 'a city',
+        n: 1,
+        size: undefined,
+        aspectRatio: undefined,
+        seed: undefined,
+        files: undefined,
+        mask: undefined,
+        providerOptions: {
+          llmgateway: {
+            style: 'photorealistic',
+          },
+        },
+        headers: {},
+      });
+
+      const body = await server.calls[0]!.requestBodyJson;
+      expect(body).toEqual({
+        model: 'qwen-image-plus',
+        prompt: 'a city',
+        n: 1,
+        response_format: 'b64_json',
+        style: 'photorealistic',
+      });
+    });
+
     it('should warn for unsupported seed', async () => {
       const result = await model.doGenerate({
         prompt: 'a dog',

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -22,6 +22,11 @@ type LLMGatewayImageConfig = {
   headers: () => Record<string, string | undefined>;
   url: (options: { modelId: string; path: string }) => string;
   fetch?: typeof fetch;
+  extraBody?: Record<string, unknown>;
+};
+
+type LLMGatewayImageModelCallOptions = ImageModelV3CallOptions & {
+  quality?: string;
 };
 
 const LLMGatewayImageResponseSchema = z.object({
@@ -55,7 +60,7 @@ export class LLMGatewayImageModel implements ImageModelV3 {
     this.provider = config.provider;
   }
 
-  async doGenerate(options: ImageModelV3CallOptions): Promise<{
+  async doGenerate(options: LLMGatewayImageModelCallOptions): Promise<{
     images: Array<string>;
     warnings: Array<SharedV3Warning>;
     response: {
@@ -104,13 +109,26 @@ export class LLMGatewayImageModel implements ImageModelV3 {
       body.aspect_ratio = options.aspectRatio;
     }
 
+    if (options.quality != null) {
+      body.quality = options.quality;
+    }
+
+    const providerOptions = options.providerOptions || {};
+    const llmgatewayOptions = providerOptions.llmgateway || {};
+    const requestBody = {
+      ...body,
+      ...this.config.extraBody,
+      ...this.settings.extraBody,
+      ...llmgatewayOptions,
+    };
+
     const { value: response, responseHeaders } = await postJsonToApi({
       url: this.config.url({
         path: hasFiles ? '/images/edits' : '/images/generations',
         modelId: this.modelId,
       }),
       headers: combineHeaders(this.config.headers(), options.headers),
-      body,
+      body: requestBody,
       failedResponseHandler: llmgatewayFailedResponseHandler,
       successfulResponseHandler: createJsonResponseHandler(
         LLMGatewayImageResponseSchema,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -167,6 +167,7 @@ export function createLLMGateway(
       url: ({ path }) => `${baseURL}${path}`,
       headers: getHeaders,
       fetch: options.fetch,
+      extraBody: options.extraBody,
     });
 
   const createLanguageModel = (

--- a/src/types/llmgateway-image-settings.ts
+++ b/src/types/llmgateway-image-settings.ts
@@ -1,3 +1,5 @@
 export type LLMGatewayImageModelId = string;
 
-export type LLMGatewayImageSettings = {};
+export type LLMGatewayImageSettings = {
+  extraBody?: Record<string, unknown>;
+};


### PR DESCRIPTION
## Summary
- Forward image `quality` into LLMGateway image request bodies.
- Add image `extraBody` support from provider settings, image model settings, and `providerOptions.llmgateway`.
- Cover image option forwarding with focused unit tests.

## Test plan
- `pnpm vitest --config vitest.node.config.ts --run src/image/index.test.ts`
- `pnpm run typecheck`


Made with [Cursor](https://cursor.com)