### PR TITLE
feat: enhance audio handling in chat message conversion

### DIFF
--- a/src/chat/convert-to-llmgateway-chat-messages.test.ts
+++ b/src/chat/convert-to-llmgateway-chat-messages.test.ts
@@ -98,6 +98,160 @@ describe('user messages', () => {
 
     expect(result).toEqual([{ role: 'user', content: 'Hello' }]);
   });
+
+  it('should convert audio Uint8Array to input_audio', async () => {
+    const result = convertToLLMGatewayChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Transcribe this' },
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/wav',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Transcribe this' },
+          {
+            type: 'input_audio',
+            input_audio: { data: 'AAECAw==', format: 'wav' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should convert audio base64 data URL to input_audio', async () => {
+    const result = convertToLLMGatewayChatMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Transcribe this' },
+          {
+            type: 'file',
+            data: 'data:audio/mpeg;base64,SUQzAAA=',
+            mediaType: 'audio/mpeg',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Transcribe this' },
+          {
+            type: 'input_audio',
+            input_audio: { data: 'SUQzAAA=', format: 'mp3' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should map common audio mime aliases to canonical formats', async () => {
+    const result = convertToLLMGatewayChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0]),
+            mediaType: 'audio/x-m4a',
+          },
+          {
+            type: 'file',
+            data: new Uint8Array([0]),
+            mediaType: 'audio/webm',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_audio',
+            input_audio: { data: 'AA==', format: 'm4a' },
+          },
+          {
+            type: 'input_audio',
+            input_audio: { data: 'AA==', format: 'webm' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should leave audio with remote http url as generic file (no inline data)', async () => {
+    const result = convertToLLMGatewayChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'https://example.com/audio.wav',
+            mediaType: 'audio/wav',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            file: {
+              filename: '',
+              file_data: 'https://example.com/audio.wav',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should leave audio with unsupported mime as generic file', async () => {
+    const result = convertToLLMGatewayChatMessages([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new Uint8Array([0, 1, 2, 3]),
+            mediaType: 'audio/3gpp',
+          },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            file: {
+              filename: '',
+              file_data: 'data:audio/3gpp;base64,AAECAw==',
+            },
+          },
+        ],
+      },
+    ]);
+  });
 });
 
 describe('cache control', () => {

--- a/src/chat/convert-to-llmgateway-chat-messages.ts
+++ b/src/chat/convert-to-llmgateway-chat-messages.ts
@@ -8,13 +8,40 @@ import type {
 } from '@ai-sdk/provider';
 import type {
   ChatCompletionContentPart,
+  ChatCompletionInputAudioFormat,
   LLMGatewayChatCompletionsInput,
 } from '../types/llmgateway-chat-completions-input';
 
 import { ReasoningDetailType } from '@/src/schemas/reasoning-details';
 
-import { getFileUrl } from './file-url-utils';
+import { getBase64FromDataUrl, getFileUrl } from './file-url-utils';
 import { isUrl } from './is-url';
+
+const AUDIO_FORMAT_BY_MIME: Record<string, ChatCompletionInputAudioFormat> = {
+  'audio/wav': 'wav',
+  'audio/wave': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/mpeg': 'mp3',
+  'audio/mp3': 'mp3',
+  'audio/mp4': 'mp4',
+  'audio/m4a': 'm4a',
+  'audio/x-m4a': 'm4a',
+  'audio/aac': 'aac',
+  'audio/ogg': 'ogg',
+  'audio/flac': 'flac',
+  'audio/aiff': 'aiff',
+  'audio/x-aiff': 'aiff',
+  'audio/webm': 'webm',
+};
+
+function audioFormatFromMime(
+  mime: string | undefined,
+): ChatCompletionInputAudioFormat | undefined {
+  if (!mime) return undefined;
+  const lower = mime.toLowerCase().split(';')[0]?.trim();
+  if (!lower) return undefined;
+  return AUDIO_FORMAT_BY_MIME[lower];
+}
 
 // Type for LLMGateway Cache Control following Anthropic's pattern
 export type LLMGatewayCacheControl = { type: 'ephemeral' };
@@ -98,6 +125,29 @@ export function convertToLLMGatewayChatMessages(
                     // For image parts, use part-specific or message-level cache control
                     cache_control: cacheControl,
                   };
+                }
+
+                if (part.mediaType?.startsWith('audio/')) {
+                  const format = audioFormatFromMime(part.mediaType);
+                  if (format) {
+                    const fileUrl = getFileUrl({
+                      part,
+                      defaultMediaType: part.mediaType,
+                    });
+                    // input_audio requires inline base64 per the OpenAI spec.
+                    // Skip remote URLs and let them fall through to the generic
+                    // file shape — fetching is the gateway/provider's job.
+                    if (fileUrl.startsWith('data:')) {
+                      return {
+                        type: 'input_audio' as const,
+                        input_audio: {
+                          data: getBase64FromDataUrl(fileUrl),
+                          format,
+                        },
+                        cache_control: cacheControl,
+                      } satisfies ChatCompletionContentPart;
+                    }
+                  }
                 }
 
                 const fileName = String(

--- a/src/types/llmgateway-chat-completions-input.ts
+++ b/src/types/llmgateway-chat-completions-input.ts
@@ -26,6 +26,7 @@ export interface ChatCompletionUserMessageParam {
 export type ChatCompletionContentPart =
   | ChatCompletionContentPartText
   | ChatCompletionContentPartImage
+  | ChatCompletionContentPartInputAudio
   | ChatCompletionContentPartFile;
 
 export interface ChatCompletionContentPartFile {
@@ -33,6 +34,29 @@ export interface ChatCompletionContentPartFile {
   file: {
     filename: string;
     file_data: string;
+  };
+  cache_control?: LLMGatewayCacheControl;
+}
+
+export type ChatCompletionInputAudioFormat =
+  | 'wav'
+  | 'mp3'
+  | 'aiff'
+  | 'aac'
+  | 'ogg'
+  | 'flac'
+  | 'm4a'
+  | 'mpeg'
+  | 'mpga'
+  | 'mp4'
+  | 'pcm'
+  | 'webm';
+
+export interface ChatCompletionContentPartInputAudio {
+  type: 'input_audio';
+  input_audio: {
+    data: string;
+    format: ChatCompletionInputAudioFormat;
   };
   cache_control?: LLMGatewayCacheControl;
 }


### PR DESCRIPTION
## Summary

Audio file parts were serialized as the generic OpenAI documents shape (`{ type: "file", file: { filename, file_data } }`), which matches PDFs and similar binaries—not audio. The OpenAI chat-completions spec uses a dedicated **`input_audio`** block (`{ type: "input_audio", input_audio: { data, format } }`), which is what downstream tooling (LLMGateway gateway, Google/Gemini transforms, OpenAI audio-capable models, etc.) expects.

This PR adds a dedicated **audio** branch in `convertToLLMGatewayChatMessages` that mirrors the existing `image_url` branch: inline audio with a recognized MIME type is emitted as **`input_audio`**; remote URLs, unrecognized MIME types, and other cases keep the existing generic **`file`** behavior.

## Motivation

With Gemini audio wired through LLMGateway, the browser gives the AI SDK a UIMessage file part with `mediaType: "audio/wav"` and a `data:` URL. The AI SDK turns that into a ModelMessage `file` part, and the provider previously serialized it as:

```json
{ "type": "file", "file": { "filename": "...", "file_data": "data:audio/wav;base64,..." } }
```

The gateway only accepts text, `image_url`, and `input_audio` content blocks, so validation returned **400**. After this change the provider emits:

```json
{ "type": "input_audio", "input_audio": { "data": "<base64>", "format": "wav" } }
```

That matches the OpenAI spec and what audio-capable transforms expect.

## Changes

### `src/types/llmgateway-chat-completions-input.ts`

- Added `ChatCompletionContentPartInputAudio` and `ChatCompletionInputAudioFormat` (12 OpenAI-supported formats: wav, mp3, aiff, aac, ogg, flac, m4a, mpeg, mpga, mp4, pcm, webm).
- Extended `ChatCompletionContentPart` to include the new variant.

### `src/chat/convert-to-llmgateway-chat-messages.ts`

- **`AUDIO_FORMAT_BY_MIME`**: maps 14 common audio MIME aliases (including `audio/x-wav`, `audio/x-m4a`, `audio/x-aiff`, `audio/wave`, `audio/mp3`) to canonical OpenAI format strings.
- **`audioFormatFromMime`**: resolves format from MIME, including stripping `;codecs=...`.
- **New `case 'file':` branch** (after image, before generic file): runs only when (a) `mediaType` starts with `audio/` and maps to a known format, and (b) data is inline (`Uint8Array` or `data:` URL). Base64 is produced via existing `getBase64FromDataUrl` / equivalent path.

### `src/chat/convert-to-llmgateway-chat-messages.test.ts`

- Uint8Array audio → `input_audio` with base64 + correct `format`
- `data:` URL audio → `input_audio`
- MIME alias (`audio/x-m4a` → `m4a`, `audio/webm` → `webm`)
- Remote `http(s)://` audio → still generic `file` (unchanged)
- Unrecognized MIME (`audio/3gpp`) → still generic `file` (unchanged)

## Behavior preserved

| Case | Result |
|------|--------|
| Image file parts | Still `image_url` |
| Non-audio, non-image files | Still generic `file` |
| Audio with remote URLs | Still generic `file` (`input_audio` is inline base64 per spec; fetching stays gateway/provider responsibility) |
| Audio with unrecognized MIME | Still generic `file` (converter stays forgiving) |