### PR TITLE
fix: declare root package in pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - .
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild


### PR DESCRIPTION
## Summary

- declare the root package in `pnpm-workspace.yaml`
- keep the existing `onlyBuiltDependencies` allowlist unchanged

## Why

With the current workspace file, pnpm 9.15.0 rejects the repo before install with:

```text
ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION packages field missing or empty
```

The contributing guide asks contributors to use pnpm 9.15.0 or higher, so adding the root package glob makes the documented setup path work.

## Validation

```bash
CI=1 corepack pnpm@9.15.0 install --frozen-lockfile
corepack pnpm@9.15.0 typecheck
corepack pnpm@9.15.0 test
corepack pnpm@9.15.0 build
```
