### PR TITLE
fix(types): type LLMGatewayChatModelId as string

### DIFF
--- a/src/types/llmgateway-chat-settings.ts
+++ b/src/types/llmgateway-chat-settings.ts
@@ -1,11 +1,9 @@
 import type { LLMGatewaySharedSettings } from '..';
-import type { models, Provider } from '../models';
 
-// Available models can be found at the LLMGateway API endpoint
-export type LLMGatewayChatModelId =
-  | (typeof models)[number]['id']
-  | `${Provider}/${(typeof models)[number]['id']}`
-  | 'test-model';
+// Available models can be found at the LLMGateway API endpoint:
+// https://api.llmgateway.io/models
+// Typed as a plain string so new models work without a package bump.
+export type LLMGatewayChatModelId = string;
 
 export type LLMGatewayChatSettings = {
   /**


### PR DESCRIPTION
## Problem

`LLMGatewayChatModelId` was a union type derived from the `@llmgateway/models` package:

```ts
export type LLMGatewayChatModelId =
  | (typeof models)[number]['id']
  | `${Provider}/${(typeof models)[number]['id']}`
  | 'test-model';
```

Two issues with this:

1. **Every new model requires a package bump.** A model isn't a valid id until `@llmgateway/models` ships it and this package upgrades — too much coupling for something that changes constantly.
2. **Consumers passing a `string` model id get a type error.** A gateway wrapper passing a dynamic `string` hits:

   ```
   error TS2769: No overload matches this call.
     Argument of type 'string' is not assignable to parameter of type 'LLMGatewayChatModelId'.
   ```

   forcing awkward casts like `this.model as Parameters<ReturnType<typeof createLLMGateway>>[0]`.

## Change

Type the chat model id as a plain `string` (matching `LLMGatewayImageModelId`, which is already `string`):

```ts
export type LLMGatewayChatModelId = string;
```

Any model id now works without a package bump or consumer-side casts.

## Notes

- `'test-model'` (used in tests) is still accepted since it's a `string`.
- The `@llmgateway/models` dependency is **retained** — it's still re-exported via the `/internal` entry point for the runtime model list. It just no longer drives the type, so adding a model no longer forces a release here.

### Alternative considered

A `LiteralUnion` pattern — `'gpt-4o' | 'claude-...' | (string & {})` — keeps editor autocomplete for known ids while accepting any string. Not used here because it still requires periodically updating the literal list, which is exactly the maintenance burden we're removing. Happy to switch to it if DX autocomplete is worth the upkeep.

## Verification

- `tsc --noEmit` passes
- `tsup` build passes; emitted `dist/index.d.ts` shows `type LLMGatewayChatModelId = string`
- All 93 node tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)